### PR TITLE
ignore .env in install.sh from git tracking

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -47,5 +47,9 @@ echo Deactivating Virtual Environment...
 deactivate
 echo
 
+echo Excluding .env file from git tracking...
+git update-index --assume-unchanged .env
+echo
+
 echo Installation Complete.
 echo


### PR DESCRIPTION
In current implementation, user needs to exclude .env file with git update-index --assume-unchanged .env. instead meera.sh install command should do it.

## Description
`git update-index --assume-unchanged .env` should be added in scripts/install.sh

## Related Issue
Closes #7

## Motivation and Context
This will avoid users accidently commiting this file.

## How Has This Been Tested?
Running of meera.sh install

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->



- [x] Travis build passes for my request
- [x] I have have made required changes in documentation.
- [x] I have read the **CONTRIBUTION** section of README.
- [x] I have manually tested the changes
- [x] I have not commited `.env` file (or I have committd it due to the context of PR)
- [x] My PR is tagged with the issue as "Bug" or "Enhancement".
